### PR TITLE
feat(common): Add top padding at the body

### DIFF
--- a/brasilcomvc/common/static/styl/common/header.styl
+++ b/brasilcomvc/common/static/styl/common/header.styl
@@ -1,8 +1,11 @@
 @import 'defs/colors'
 
+header-height = 75px
+
+body
+	padding-top header-height
 
 header
-	header-height = 75px
 	item-height = 52px
 
 	background color_text_lighter


### PR DESCRIPTION
As the header have a fixed position, the body needs a top padding so the content won't be behind the header on user scroll
